### PR TITLE
Updating font and colors to match new theme 

### DIFF
--- a/assets/pmgbootstrap/_button.scss
+++ b/assets/pmgbootstrap/_button.scss
@@ -1,42 +1,4 @@
 .btn {
-    &.btn-default {
-        /* Base: */
-        background-image: linear-gradient(0deg, #F2F4F7 0%, #FFFFFF 100%);
-        &:hover {
-            background-image: linear-gradient(to bottom, #fff, #fafafa)
-        }
-    }
-    &.btn-primary {
-        background-image: linear-gradient(-180deg, $brand-primary-light 0%, $brand-primary 100%);
-        &:hover {
-            background-image: linear-gradient(-180deg, $brand-primary 0%, $brand-primary-dark 100%);
-        }
-    }
-    &.btn-success {
-        background-image: linear-gradient(-180deg, $brand-success-light 0%, $brand-success 100%);
-        &:hover {
-            background-image: linear-gradient(-180deg, $brand-success 0%, $brand-success-dark 100%);
-        }
-    }
-    &.btn-info {
-        background-image: linear-gradient(-180deg, $brand-info-light 0%, $brand-info 100%);
-        &:hover {
-            background-image: linear-gradient(-180deg, $brand-info 0%, $brand-info-dark 100%);
-        }
-    }
-    &.btn-warning {
-        background-image: linear-gradient(-180deg, $brand-warning-light 0%, $brand-warning 100%);
-        &:hover {
-            background-image: linear-gradient(-180deg, $brand-warning 0%, $brand-warning-dark 100%);
-        }
-    }
-    &.btn-danger {
-        background-image: linear-gradient(-180deg, $brand-danger-light 0%, $brand-danger 100%);
-        &:hover {
-            background-image: linear-gradient(-180deg, $brand-danger 0%, $brand-danger-dark 100%);
-        }
-    }
-
     &.btn-link-primary {
         @extend .btn-link;
         color: $brand-primary;

--- a/assets/pmgbootstrap/_button.scss
+++ b/assets/pmgbootstrap/_button.scss
@@ -1,37 +1,55 @@
 .btn {
+    border: none;
+    transition: .2s;
     &.btn-link-primary {
         @extend .btn-link;
         color: $brand-primary;
         &:hover {
-            color: $brand-primary-dark;
+            color: $brand-primary-light;
         }
     }
     &.btn-link-success {
         @extend .btn-link;
         color: $brand-success;
         &:hover {
-            color: $brand-success-dark;
+            color: $brand-success-light;
         }
     }
     &.btn-link-info {
         @extend .btn-link;
         color: $brand-info;
         &:hover {
-            color: $brand-info-dark;
+            color: $brand-info-light;
         }
     }
     &.btn-link-warning {
         @extend .btn-link;
         color: $brand-warning;
         &:hover {
-            color: $brand-warning-dark;
+            color: $brand-warning-light;
         }
     }
     &.btn-link-danger {
         @extend .btn-link;
         color: $brand-danger;
         &:hover {
-            color: $brand-danger-dark;
+            color: $brand-danger-light;
         }
+    }
+
+    &.btn-primary:hover {
+        background: $brand-primary-light;
+    }
+    &.btn-success:hover {
+        background: $brand-success-light;
+    }
+    &.btn-info:hover {
+        background: $brand-info-light;
+    }
+    &.btn-warning:hover {
+        background: $brand-warning-light;
+    }
+    &.btn-danger:hover {
+        background: $brand-danger-light;
     }
 }

--- a/assets/pmgbootstrap/_variables.scss
+++ b/assets/pmgbootstrap/_variables.scss
@@ -9,28 +9,33 @@ $bootstrap-sass-asset-helper: false;
 //## Gray and brand colors for use across Bootstrap.
 
 $gray-base:              #c2c2c2;
-$gray-darker:            #222; //
+$gray-darker:            #3E3F42; //
 $gray-dark:              darken($gray-base, 30%);   // #8F8F8F
 $gray:                   $gray-base; //#c2c2c2
 $gray-light:             lighten($gray-base, 10%); //#dcdcdc
 $gray-lighter:           lighten($gray-base, 21%); //#f8f8f8
 
 $base-background-color: #f5f7fb;
-$brand-primary:         #36406b;
+
+$brand-primary:         #0C69EA;
 $brand-primary-light:   lighten($brand-primary, 10%); //#47548d
-$brand-primary-dark:    darken($brand-primary, 10%); //#36406b
-$brand-success:         #318e30;
+$brand-primary-dark:    #0E5BD7;
+
+$brand-success:         #389E0D;
 $brand-success-light:   lighten($brand-success, 10%); //#3eb43d
-$brand-success-dark:    darken($brand-success, 10%); //#318e30
-$brand-info:            #3a8ea7;
+$brand-success-dark:    #237804;
+
+$brand-info:            #03A595;
 $brand-info-light:      lighten($brand-info, 10%); //#51a9c3
-$brand-info-dark:       darken($brand-info, 10%); //#3a8ea7
-$brand-warning:         #E89B2C;
+$brand-info-dark:       #00877F;
+
+$brand-warning:         #FA8C16;
 $brand-warning-light:   lighten($brand-warning, 10%); //#edb15a
-$brand-warning-dark:    darken($brand-warning, 10%); //#E89B2C
-$brand-danger:          #B2201B;
+$brand-warning-dark:    #D46B08;
+
+$brand-danger:          #D6010D;
 $brand-danger-light:    lighten($brand-danger, 10%); //#de2922
-$brand-danger-dark:     darken($brand-danger, 10%); //#B2201B
+$brand-danger-dark:     #BD000C;
 
 //== Scaffolding
 //
@@ -53,13 +58,13 @@ $link-hover-decoration: underline;
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif:  -apple-system, BlinkMacSystemFont, 'Source Sans Pro', "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-family-sans-serif:  -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 $font-family-serif:       Georgia, "Times New Roman", Times, serif;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 $font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 $font-family-base:        $font-family-sans-serif;
 
-$font-size-base:          14px;
+$font-size-base:          16px;
 $font-size-large:         ceil(($font-size-base * 1.25)); // ~18px
 $font-size-small:         ceil(($font-size-base * 0.85)); // ~12px
 
@@ -511,21 +516,21 @@ $jumbotron-heading-font-size:    ceil(($font-size-base * 4.5));
 //
 //## Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             $brand-success;
-$state-success-bg:               lighten($brand-success-light, 38%);
-$state-success-border:           darken(adjust-hue($state-success-bg, -10), 5%);
+$state-success-text:             $gray-darker;
+$state-success-bg:               #F6FFED;
+$state-success-border:           #B7EB8F;
 
-$state-info-text:                $brand-info;
-$state-info-bg:                  lighten($brand-info-light, 25%);
-$state-info-border:              darken(adjust-hue($state-info-bg, -10), 7%);
+$state-info-text:                $gray-darker;
+$state-info-bg:                  #E6F7FF;
+$state-info-border:              #4DABFF;
 
-$state-warning-text:             $brand-warning;
-$state-warning-bg:               lighten($brand-warning-light, 19%);
-$state-warning-border:           darken(adjust-hue($state-warning-bg, -10), 5%);
+$state-warning-text:             $gray-darker;
+$state-warning-bg:               #FFF7E6;
+$state-warning-border:           #FFD591;
 
-$state-danger-text:              $brand-danger;
-$state-danger-bg:                lighten($brand-danger-light, 29%);
-$state-danger-border:            darken(adjust-hue($state-danger-bg, -10), 5%);
+$state-danger-text:              $gray-darker;
+$state-danger-bg:                #FFF1F0;
+$state-danger-border:            #FFA39E;
 
 //== Tooltips
 //

--- a/assets/pmgbootstrap/_variables.scss
+++ b/assets/pmgbootstrap/_variables.scss
@@ -165,7 +165,7 @@ $table-border-color:            #eee;
 $btn-font-weight:                normal;
 
 $btn-default-color:              darken($gray-dark, 10%);
-$btn-default-bg:                 #D9D9D9;
+$btn-default-bg:                 #E8E8E8;
 $btn-default-border:             $btn-default-bg;
 
 $btn-primary-color:              #fff;

--- a/assets/pmgbootstrap/_variables.scss
+++ b/assets/pmgbootstrap/_variables.scss
@@ -18,23 +18,23 @@ $gray-lighter:           lighten($gray-base, 21%); //#f8f8f8
 $base-background-color: #f5f7fb;
 
 $brand-primary:         #0C69EA;
-$brand-primary-light:   lighten($brand-primary, 10%); //#47548d
+$brand-primary-light:   #0F7AF7;
 $brand-primary-dark:    #0E5BD7;
 
 $brand-success:         #389E0D;
-$brand-success-light:   lighten($brand-success, 10%); //#3eb43d
+$brand-success-light:   #52C41A;
 $brand-success-dark:    #237804;
 
 $brand-info:            #03A595;
-$brand-info-light:      lighten($brand-info, 10%); //#51a9c3
+$brand-info-light:      #2BBBAA;
 $brand-info-dark:       #00877F;
 
 $brand-warning:         #FA8C16;
-$brand-warning-light:   lighten($brand-warning, 10%); //#edb15a
+$brand-warning-light:   #FFA940;
 $brand-warning-dark:    #D46B08;
 
 $brand-danger:          #D6010D;
-$brand-danger-light:    lighten($brand-danger, 10%); //#de2922
+$brand-danger-light:    #E4292D;
 $brand-danger-dark:     #BD000C;
 
 //== Scaffolding
@@ -165,12 +165,12 @@ $table-border-color:            #eee;
 $btn-font-weight:                normal;
 
 $btn-default-color:              darken($gray-dark, 10%);
-$btn-default-bg:                 $gray-lighter;
-$btn-default-border:             #CED0DA;
+$btn-default-bg:                 #D9D9D9;
+$btn-default-border:             $btn-default-bg;
 
 $btn-primary-color:              #fff;
 $btn-primary-bg:                 $brand-primary;
-$btn-primary-border:             darken($btn-primary-bg, 5%);
+$btn-primary-border:             $brand-primary;
 
 $btn-success-color:              #fff;
 $btn-success-bg:                 $brand-success;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@agencypmg/bootstrap-theme",
-  "version": "4.0.6",
+  "version": "4.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agencypmg/bootstrap-theme",
-  "version": "4.0.8",
+  "version": "4.1.0",
   "description": "PMGs bootstrap theme",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
**Before**

<img width="703" alt="Screen Shot 2020-02-04 at 11 38 08 AM" src="https://user-images.githubusercontent.com/6569484/73771175-7afcf300-4743-11ea-871f-06676bfcbbf1.png">
<img width="1170" alt="Screen Shot 2020-02-04 at 11 38 17 AM" src="https://user-images.githubusercontent.com/6569484/73771177-7b958980-4743-11ea-946c-d273bdc93e4d.png">


**After**

<img width="727" alt="Screen Shot 2020-02-04 at 11 38 12 AM" src="https://user-images.githubusercontent.com/6569484/73771176-7b958980-4743-11ea-8d41-4f3597feb969.png">

<img width="1199" alt="Screen Shot 2020-02-04 at 11 38 23 AM" src="https://user-images.githubusercontent.com/6569484/73771178-7b958980-4743-11ea-9cf2-15d1978cd5ca.png">


This brings it inline with ANT theme as we work on sidebar