### PR TITLE
fixing tab and adding table

### DIFF
--- a/assets/pmgbootstrap/_table.scss
+++ b/assets/pmgbootstrap/_table.scss
@@ -28,4 +28,10 @@ table,
     th:first-child {
         border-left: none;
     }
+
+  &.center-first-col {
+      tr td:first-child {
+          text-align: center;
+      }
+  }
 }

--- a/assets/pmgbootstrap/_theme.scss
+++ b/assets/pmgbootstrap/_theme.scss
@@ -144,7 +144,8 @@ h1.inline-button {
         &:hover {
             border-color: $brand-primary;
             a,
-            a:hover {
+            a:hover,
+            a:focus {
                 border: none;
             }
         }

--- a/assets/pmgbootstrap/_variables.scss
+++ b/assets/pmgbootstrap/_variables.scss
@@ -145,7 +145,7 @@ $caret-width-large:         5px;
 //## Customizes the `.table` component with basic values, each used across all table variations.
 
 //** Padding for `<th>`s and `<td>`s.
-$table-cell-padding:            12px 8px;
+$table-cell-padding:            12px 10px;
 //** Padding for cells in `.table-condensed`.
 $table-condensed-cell-padding:  5px;
 

--- a/index.html
+++ b/index.html
@@ -200,6 +200,40 @@
                             </tbody>
                         </table>
                     </div>
+                    <div class="col-md-12">
+                        <p>center-first-col table example</p>
+                        <table class="table center-first-col">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th><a href="">First Name</a></th>
+                                    <th>Last Name</th>
+                                    <th>Username</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>1</td>
+                                    <td>Mark</td>
+                                    <td>Otto</td>
+                                    <td>@mdo</td>
+                                </tr>
+                                <tr>
+                                    <td>2</td>
+                                    <td>Jacob</td>
+                                    <td>Thornton</td>
+                                    <td>@fat</td>
+                                </tr>
+                                <tr>
+                                    <td>3</td>
+                                    <td>Larry</td>
+                                    <td>the Bird</td>
+                                    <td>@twitter</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
                 </div>
 
                 <div class="row">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agencypmg/bootstrap-theme",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "PMGs bootstrap theme",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
Fixes the tab issue where focused tabs appear larger 
<img width="480" alt="Screen Shot 2020-03-31 at 2 23 28 PM" src="https://user-images.githubusercontent.com/6569484/78066809-38c6eb00-735b-11ea-848e-ee79fef4b739.png">


And adds a `.center-first-col` class for tables like this 

**Before**
<img width="630" alt="Screen Shot 2020-03-31 at 2 24 03 PM" src="https://user-images.githubusercontent.com/6569484/78066891-64e26c00-735b-11ea-810b-81f60311977a.png">


**After**
<img width="1247" alt="Screen Shot 2020-03-31 at 2 24 37 PM" src="https://user-images.githubusercontent.com/6569484/78066895-6744c600-735b-11ea-851d-b07ca88b6771.png">


<img width="1227" alt="Screen Shot 2020-03-31 at 2 23 02 PM" src="https://user-images.githubusercontent.com/6569484/78066768-277dde80-735b-11ea-9323-d1050440ed01.png">
